### PR TITLE
ci: releases-only upstream sync + ARM64 GHCR release with Coolify webhook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Start GitHub Deployment
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.trigger_coolify }}
+        id: gh_deploy_start
+        uses: bobheadxi/deployments@v1
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: production
+          ref: ${{ github.sha }}
+          description: "Coolify deploy"
+
       - name: Load secrets from 1Password
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.trigger_coolify }}
         uses: 1password/load-secrets-action@v2
@@ -116,3 +127,21 @@ jobs:
             -H "Authorization: Bearer ${COOLIFY_API_KEY}" \
             "$COOLIFY_WEBHOOK_URL"
 
+
+      - name: Mark deployment success
+        if: ${{ (github.event_name != 'workflow_dispatch' || inputs.trigger_coolify) && success() }}
+        uses: bobheadxi/deployments@v1
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: success
+          deployment_id: ${{ steps.gh_deploy_start.outputs.deployment_id }}
+
+      - name: Mark deployment failure
+        if: ${{ (github.event_name != 'workflow_dispatch' || inputs.trigger_coolify) && failure() }}
+        uses: bobheadxi/deployments@v1
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: failure
+          deployment_id: ${{ steps.gh_deploy_start.outputs.deployment_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,21 @@ name: Release (ARM64) to GHCR + Coolify
 on:
   push:
     branches: [ main ]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g., v2.11.4). Leave empty to auto bump patch."
+        required: false
+        type: string
+      release_notes:
+        description: "Custom release notes (optional). Overrides auto-generated notes."
+        required: false
+        type: string
+      trigger_coolify:
+        description: "Trigger Coolify deployment after publish"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -23,24 +37,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine next version tag (patch bump)
+      - name: Determine version tag (auto bump or manual input)
         id: version
         shell: bash
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          git fetch --tags --force
-          LATEST=$(git tag -l 'v*' --sort=-v:refname | head -n1 || true)
-          if [[ -z "$LATEST" ]]; then
-            LATEST="v0.0.0"
+          if [[ -n "${VERSION_INPUT:-}" ]]; then
+            # Use manual version input
+            if [[ ! "${VERSION_INPUT}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Invalid version tag format: ${VERSION_INPUT}. Expected vMAJOR.MINOR.PATCH" >&2
+              exit 1
+            fi
+            NEXT="${VERSION_INPUT}"
+          else
+            # Auto bump patch from latest v* tag
+            git fetch --tags --force
+            LATEST=$(git tag -l 'v*' --sort=-v:refname | head -n1 || true)
+            if [[ -z "$LATEST" ]]; then
+              LATEST="v0.0.0"
+            fi
+            ver="${LATEST#v}"
+            IFS='.' read -r MA MI PA <<<"$ver"
+            if [[ -z "$MA" || -z "$MI" || -z "$PA" ]]; then
+              echo "Unexpected latest tag format: $LATEST" >&2
+              exit 1
+            fi
+            NEXT="v${MA}.${MI}.$((PA+1))"
           fi
-          # bump patch
-          ver="${LATEST#v}"
-          IFS='.' read -r MA MI PA <<<"$ver"
-          if [[ -z "$MA" || -z "$MI" || -z "$PA" ]]; then
-            echo "Unexpected latest tag format: $LATEST" >&2
-            exit 1
-          fi
-          NEXT="v${MA}.${MI}.$((PA+1))"
           echo "VERSION=${NEXT}" | tee -a "$GITHUB_ENV"
           echo "version=${NEXT}" >> "$GITHUB_OUTPUT"
 
@@ -64,15 +89,17 @@ jobs:
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
 
-      - name: Create GitHub Release (auto notes)
+      - name: Create GitHub Release (auto or custom notes)
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.VERSION }}
-          generate_release_notes: true
+          generate_release_notes: ${{ inputs.release_notes == '' }}
+          body: ${{ inputs.release_notes }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load secrets from 1Password
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.trigger_coolify }}
         uses: 1password/load-secrets-action@v2
         with:
           export-env: true
@@ -81,6 +108,7 @@ jobs:
           COOLIFY_API_KEY: "op://SECRETS/Coolify/API_Token"
 
       - name: Trigger Coolify Deploy (by UUID)
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.trigger_coolify }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release (ARM64) to GHCR + Coolify
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/carsaig/n8n-mcp
+  COOLIFY_WEBHOOK_URL: https://coolify.certain.cc/api/v1/deploy?uuid=dokk88s84sgcwg848k044o4k&force=false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine next version tag (patch bump)
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          LATEST=$(git tag -l 'v*' --sort=-v:refname | head -n1 || true)
+          if [[ -z "$LATEST" ]]; then
+            LATEST="v0.0.0"
+          fi
+          # bump patch
+          ver="${LATEST#v}"
+          IFS='.' read -r MA MI PA <<<"$ver"
+          if [[ -z "$MA" || -z "$MI" || -z "$PA" ]]; then
+            echo "Unexpected latest tag format: $LATEST" >&2
+            exit 1
+          fi
+          NEXT="v${MA}.${MI}.$((PA+1))"
+          echo "VERSION=${NEXT}" | tee -a "$GITHUB_ENV"
+          echo "version=${NEXT}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (ARM64 only)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+
+      - name: Create GitHub Release (auto notes)
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.VERSION }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          COOLIFY_API_KEY: "op://SECRETS/Coolify/API_Token"
+
+      - name: Trigger Coolify Deploy (by UUID)
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer ${COOLIFY_API_KEY}" \
+            "$COOLIFY_WEBHOOK_URL"
+

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -3,8 +3,8 @@ name: Upstream Sync
 on:
   workflow_dispatch: {}
   schedule:
-    # Weekdays 07:00 UTC ≈ 09:00 Europe/Berlin (Renovate window-friendly)
-    - cron: "0 7 * * 1-5"
+    # Daily 12:00 CET (fixed at 11:00 UTC year-round)
+    - cron: "0 11 * * *"
 
 permissions:
   contents: write
@@ -14,6 +14,9 @@ env:
   UPSTREAM_URL: https://github.com/czlonkowski/n8n-mcp.git   # ← replace
   UPSTREAM_BRANCH: main                                      # ← replace if different
   SYNC_BRANCH: chore/upstream-sync
+  UPSTREAM_OWNER: czlonkowski
+  UPSTREAM_REPO: n8n-mcp
+
 
 jobs:
   sync:
@@ -25,46 +28,69 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Add upstream and fetch
-        run: |
-          git remote add upstream "${UPSTREAM_URL}" || true
-          git fetch upstream --prune
-          git checkout -B "${SYNC_BRANCH}"
-          # Merge upstream with a merge commit so history is explicit
-          git merge --no-ff --no-edit "upstream/${UPSTREAM_BRANCH}" || true
+      - name: Ensure jq is available
+        run: sudo apt-get update -y && sudo apt-get install -y jq
 
-      - name: No changes? Exit early
-        id: diffcheck
+      - name: Resolve latest upstream release tag
+        id: latest
         run: |
-          if git diff --quiet HEAD "upstream/${UPSTREAM_BRANCH}"; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-          else
-            echo "changed=true" >> $GITHUB_OUTPUT
+          set -e
+          TAG=$(curl -sL "https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/latest" | jq -r '.tag_name')
+          if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+            echo "No release tag found" >&2
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare sync branch from latest release tag
+        id: prep
+        if: steps.latest.outputs.tag != ''
+        run: |
+          set -e
+          git remote add upstream "${UPSTREAM_URL}" || true
+          git fetch upstream --prune --tags
+          TAG="${{ steps.latest.outputs.tag }}"
+          # Ensure the release tag is available locally
+          git fetch upstream "refs/tags/${TAG}:refs/tags/${TAG}" || true
+          # Determine if the release tag commit is already in origin/main
+          git fetch origin main
+          TAG_COMMIT="$(git rev-list -n 1 "${TAG}")"
+          if git merge-base --is-ancestor "${TAG_COMMIT}" origin/main; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BRANCH="chore/upstream-sync-${TAG}"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          # Create branch at upstream release tag to open a PR against our main
+          git checkout -B "${BRANCH}" "${TAG}"
+
+      - name: Evaluate change status
+        id: diffcheck
+        if: steps.latest.outputs.tag != ''
+        run: |
+          echo "changed=${{ steps.prep.outputs.changed }}" >> "$GITHUB_OUTPUT"
 
       - name: Push sync branch
         if: steps.diffcheck.outputs.changed == 'true'
         run: |
-          git push -u origin "${SYNC_BRANCH}"
+          git push -u origin "${{ steps.prep.outputs.branch }}"
 
       - name: Create or update PR
+        id: cpr
         if: steps.diffcheck.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          branch: ${{ env.SYNC_BRANCH }}
-          title: "chore: sync from upstream/${{ env.UPSTREAM_BRANCH }}"
+          branch: ${{ steps.prep.outputs.branch }}
+          title: "chore: sync upstream release ${{ steps.latest.outputs.tag }}"
           body: |
-            This PR merges changes from **${{ env.UPSTREAM_URL }}** (`${{ env.UPSTREAM_BRANCH }}`) into this repo.
+            This PR merges upstream release `${{ steps.latest.outputs.tag }}` from **${{ env.UPSTREAM_URL }}** into this repo.
 
             - CI must be green (branch protection enforces this).
-            - Renovate will propose any follow-up dependency bumps on top (normal flow).
           labels: |
             dependencies
             upstream-sync
-          reviewers: |
-            czlonkowski
-          assignees: |
-            czlonkowski
           signoff: true
           delete-branch: false
 
@@ -72,5 +98,5 @@ jobs:
         if: steps.diffcheck.outputs.changed == 'true'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          pull-request-number: ${{ steps.create_pull_request.outputs.pull-request-number }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: squash

--- a/docs/customizations/github-workflows.md
+++ b/docs/customizations/github-workflows.md
@@ -5,56 +5,120 @@ This document describes the fork-specific workflows that protect customizations,
 ## Required Checks Workflow (.github/workflows/required-checks.yml)
 
 Purpose:
-- Gate all PRs and pushes to main with type checks, unit tests, and project validators
-- Enforce protection for fork customizations declared in `.github/customizations.yml`
-- Provide an informational impact analysis based on `impact_watch` and `tracked_deltas`
+
+*   Gate all PRs and pushes to main with type checks, unit tests, and project validators
+*   Enforce protection for fork customizations declared in `.github/customizations.yml`
+*   Provide an informational impact analysis based on `impact_watch` and `tracked_deltas`
 
 Key behavior:
-1) Policy job (pull_request only)
-   - Reads `.github/customizations.yml`
-   - Extracts all `customizations[].paths` entries
-   - Uses GitHub API to list changed files in the PR
-   - If any protected path is changed without PR label `customization-change`, the job fails
-2) Checks job (always)
-   - `npm ci`
-   - `npm run typecheck`
-   - `npm test -- --run`
-   - `npm run validate`
+
+1.  Policy job (pull\_request only)
+    *   Reads `.github/customizations.yml` (if missing: warns and skips enforcement)
+    *   Lists changed files via GitHub API
+    *   Fetches PR labels via API (avoids stale event payload)
+    *   If a protected path requires label `customization-change` and it's missing, the job fails
+2.  Checks job (pull\_request and push to `main`)
+    *   Setup Node.js 20.x with npm cache
+    *   Install deps: `npm install --no-audit --no-fund --prefer-offline --legacy-peer-deps`
+    *   Typecheck: `npm run typecheck`
+    *   Unit tests: currently skipped in CI for stability
+    *   Build: `npm run build`
+    *   Validators: `npm run validate`
 
 Notes:
-- The policy job uses actions/github-script (Node) to avoid external dependencies on the runner
-- For approval requirements (e.g. CODEOWNERS), configure branch protection rules in GitHub settings
+
+*   The policy job uses `actions/github-script` (Node) and queries the GitHub API directly
+*   Use GitHub rulesets/branch protection to require these status checks; approvals are optional by your preference
+*   Runner: self-hosted linux/arm64; keep workflow minimal/deterministic for reliability
 
 ## Upstream Sync Workflow (.github/workflows/upstream-sync.yml)
 
 Purpose:
-- Periodically (or manually) fetch, merge and raise a PR that syncs `upstream/main` into this fork
-- Labels the PR as `upstream-sync` and `dependencies`
-- Relies on the Required Checks workflow to evaluate policy and run validations
+
+*   Periodically (or manually) fetch, merge and raise a PR that syncs `upstream/main` into this fork
+*   Labels the PR as `upstream-sync` and `dependencies`
+*   Relies on the Required Checks workflow to evaluate policy and run validations
 
 Key behavior:
-- Creates/updates branch `chore/upstream-sync`
-- Opens a PR with labels so policy and checks are applied consistently
-- Auto-merge can be enabled when checks are green
+
+*   Creates/updates branch `chore/upstream-sync`
+*   Opens a PR with labels so policy and checks are applied consistently
+*   Auto-merge can be enabled when checks are green
 
 ## Customizations Manifest (.github/customizations.yml)
 
 This manifest drives policy and impact analysis. Structure:
-- `policies`: description of gating logic and checks
-- `checks`: named commands (typecheck, unit-tests, workflow-validators)
-- `mirrors`: parts that upstream owns (e.g. upstream-workflows/**)
-- `customizations[]`: protected groups with `paths`, optional `checksums`, and optional `impact_watch`
-- `tracked_deltas`: additional files that differ from upstream for broader impact detection
+
+*   `policies`: description of gating logic and checks
+*   `checks`: named commands (typecheck, unit-tests, workflow-validators)
+*   `mirrors`: parts that upstream owns (e.g. upstream-workflows/\*\*)
+*   `customizations[]`: protected groups with `paths`, optional `checksums`, and optional `impact_watch`
+*   `tracked_deltas`: additional files that differ from upstream for broader impact detection
 
 Maintenance hints:
-- When you intentionally update a protected file, add `customization-change` label to the PR
-- For critical files with checksums, update the hash in the manifest in the same PR
-- Add new customizations or tracked paths in the manifest as your fork evolves
+
+*   When you intentionally update a protected file, add `customization-change` label to the PR
+*   For critical files with checksums, update the hash in the manifest in the same PR
+*   Add new customizations or tracked paths in the manifest as your fork evolves
 
 ## Operational Recommendations
 
-- Use CODEOWNERS to require explicit review for sensitive paths (e.g. MCP server files, workflows)
-- Keep `required-checks.yml` minimal and deterministic; avoid environment surprises on self-hosted runners
-- Prefer manifest-driven enforcement over duplicated path lists inside workflows
-- For non-trivial upstream changes, review impact hits printed by the policy job and expand tests where necessary
+*   Use CODEOWNERS to require explicit review for sensitive paths (e.g. MCP server files, workflows)
 
+## Step-by-step runbook: checks and rules (concise)
+
+Step 0: Trigger
+
+*   Action: Open/update a PR, or push to `main`.
+*   Why: Gate changes with policy and checks.
+*   Effect: On PRs, both jobs run; on `main` pushes, only the checks job runs.
+
+Step 1: Policy job (PR only)
+
+*   Actions:
+    *   Checkout the PR code
+    *   Read `.github/customizations.yml` (warn and skip if missing)
+    *   List changed files via GitHub API
+    *   Fetch PR labels via GitHub API (fresh, non-stale)
+    *   Match changed files against protected paths from the manifest
+*   Why: Ensure sensitive/customized areas are only changed intentionally
+*   Effect:
+    *   If protected paths changed and label `customization-change` is absent → job fails
+    *   Otherwise → job passes (may emit warnings for soft-guard paths)
+
+Step 2: Checks job (PRs and `main`)
+
+*   Actions:
+    *   Setup Node.js 20.x (with npm cache)
+    *   Install deps: `npm install --no-audit --no-fund --prefer-offline --legacy-peer-deps`
+    *   Typecheck: `npm run typecheck`
+    *   Tests: currently skipped in CI for stability
+    *   Build: `npm run build`
+    *   Validators: `npm run validate`
+*   Why: Fast, deterministic signal that the project compiles and passes validators on the runner
+*   Effect: Produces the required status checks gating merges
+
+Step 3: Merge and required rules
+
+*   Actions:
+    *   GitHub ruleset/branch protection requires successful “Required Checks” statuses
+    *   No mandatory approvals (per your preference); CODEOWNERS can still be used if desired
+*   Why: Keep merges unblocked for solo operation while retaining CI gating
+*   Effect: You can merge as soon as both statuses are green
+
+Step 4: After merge to `main`
+
+*   Actions: The checks job runs on `main` again (build + validators)
+*   Why: Post-merge smoke to ensure `main` remains healthy
+*   Effect: Confirms deployable state
+
+Step 5: Branch cleanup
+
+*   Actions:
+    *   Auto-delete of head branches on merge is enabled at repo level
+    *   Manual cleanup is done for older branches if any remain
+*   Why: Keep the repo tidy
+*   Effect: No stale branches after merges
+*   Keep `required-checks.yml` minimal and deterministic; avoid environment surprises on self-hosted runners
+*   Prefer manifest-driven enforcement over duplicated path lists inside workflows
+*   For non-trivial upstream changes, review impact hits printed by the policy job and expand tests where necessary


### PR DESCRIPTION
This PR implements the automation we discussed:

1) Upstream Sync (releases-only)
- Schedule: daily at 12:00 CET (11:00 UTC)
- Detects latest upstream release tag from czlonkowski/n8n-mcp and opens a PR only when your main does not yet contain that release
- Creates branch chore/upstream-sync-<tag> at the upstream release tag and opens PR against main (checks/policy will run normally)
- Keeps labels and auto-merge step

2) Release to GHCR (ARM64 only) + Coolify webhook
- On push to main (and manual dispatch):
  - Bumps SemVer patch from latest v* tag (e.g., v2.11.3 -> v2.11.4)
  - Builds and pushes ARM64-only image to ghcr.io/carsaig/n8n-mcp with tags latest and vX.Y.Z
  - Creates a GitHub Release with auto-generated notes
  - Loads COOLIFY_API_KEY via 1Password and POSTs to your Coolify webhook to trigger deployment

Notes:
- Ensure repo secret OP_SERVICE_ACCOUNT_TOKEN exists for the 1Password action
- The release job sets permissions: contents: write and packages: write

Once merged, your daily upstream sync reacts to upstream releases only, and merges to main will publish ARM64 images and trigger Coolify.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author