### PR TITLE
ci(release): grant PR/issue permissions for compose/docs bump step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ on:
 permissions:
   contents: write
   packages: write
+  pull-requests: write
+  issues: write
 
 env:
   IMAGE_NAME: ghcr.io/carsaig/n8n-mcp
@@ -145,6 +147,8 @@ jobs:
       contents: write
       packages: write
       deployments: write
+      pull-requests: write
+      issues: write
     steps:
       - name: Create GitHub Release (auto or custom notes)
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This PR adds the minimal permissions required for peter-evans/create-pull-request to open the compose+docs bump PR during the Release workflow:

- pull-requests: write
- issues: write

Once merged, the next Release run will successfully create the bump PR and continue to Deployment (Coolify webhook).

Note: Pushing directly to main is blocked by repository rules (required PR + status checks), so this PR is required to deliver the fix.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author